### PR TITLE
Added universal User-Data-Header interpreter, code refactoring

### DIFF
--- a/src/pdulib.h
+++ b/src/pdulib.h
@@ -244,7 +244,7 @@ private:
   void digitSwap(const char *number, char *pdu);
   
   int utf8_to_packed7bit(const char *utf8, char *pdu, int *septets, int UDHsize, int availableSpace);
-  int pduGsm7_to_unicode(const char *pdu, int pdulength, char *ascii,char firstchar);
+  int pduGsm7_to_unicode(const char *pdu, int pdulength, char *ascii, int fillBits = 0);
 
   int convert_utf8_to_gsm7bit(const char *ascii, char *a7bit, int udhsize, int availableSpace);
   int convert_7bit_to_unicode(unsigned char *a7bit, int length, char *ascii);


### PR DESCRIPTION
Hi.
I had a problem with clipping first letter in messages with user data header so I started fixing it. I used platformio version so I didn't know at the time that you already fixed it.
Regardless, I did some refactoring, mainly the data header processing. You only expect two types of headers, but there is a possibility that there are others, and there might be more than one at the same time, I added that.
Also I don't know where the Information Element Identifier of 8 come from (the 16bit reference number for concat messages), the documentation doesn't mention this type.
I hope it will be useful.
