### PR TITLE
fix: MAX_NUMBER_LENGTH too small

### DIFF
--- a/src/pdulib.h
+++ b/src/pdulib.h
@@ -62,7 +62,7 @@
 
 #define MAX_SMS_LENGTH_7BIT 160 // GSM 3.4
 #define MAX_NUMBER_OCTETS 140
-#define MAX_NUMBER_LENGTH 20    // gets packed into BCD or packed 7 bit
+#define MAX_NUMBER_LENGTH 21    // gets packed into BCD or packed 7 bit
 #define UTF8_BUFFSIZE 100   // tailor to what you need
 
 //SCA (12) + type + mref + address(12) + pid + dcs + length + data(140) -- no valtime


### PR DESCRIPTION
[MAX_NUMBER_LENGTH](https://github.com/mgaman/PDUlib/blob/5eb03492a7e6785c0572647d9a8924b7ea4e2fcf/src/pdulib.h#L65) does not take into account the '\0' at the end of the string.

When dealing with SMS messages with a 20-digit sender number, '\0' is written to memory outside the string [here](https://github.com/mgaman/PDUlib/blob/5eb03492a7e6785c0572647d9a8924b7ea4e2fcf/src/pdulib.cpp#L1025), leading to other serious problems (in my scenario, generalWorkBuffLength is written as 0).