### PR TITLE
Fix PDU decoding failure when sender address has unsupported TON type

### DIFF
--- a/src/pdulib.cpp
+++ b/src/pdulib.cpp
@@ -1047,13 +1047,19 @@ int PDU::decodeAddress(const char *pdu, char *output, eLengthType et)
         addressLength++;            // we could do NOT this before calling pduGsm7_to_unicode
       break;
     default:
-      addressLength = 0;
+      // Unknown TON type - don't decode but still need to skip over the address bytes
+      *output = 0;  // empty output string
+      if ((addressLength & 1) == 1) // if odd, bump 1
+        addressLength++;
       break;
     }
   }
   else
   {
-    addressLength = 0; // dont know how to handle EXT
+    // Unknown EXT format - don't decode but still need to skip over the address bytes
+    *output = 0;  // empty output string
+    if ((addressLength & 1) == 1) // if odd, bump 1
+      addressLength++;
   }
   return addressLength;
 }


### PR DESCRIPTION
> fix https://github.com/mgaman/PDUlib/issues/48

### Problem

When decoding a PDU with an unsupported sender address Type of Number (TON), such as TON=3 (network specific number) or TON=6 (abbreviated number), the `decodeAddress` function incorrectly sets `addressLength` to 0 and returns 0.

This causes `decodePDU` to miscalculate the index offset, since it uses the return value to skip over the address field:
```cpp
index += i + 4; // skip over sender number length & atn
```

When `i = 0`, only 4 hex characters are skipped (length + address type), but the actual address data is not skipped. This results in all subsequent parsing (PID, DCS, timestamp, user data) starting from the wrong offset, producing garbled output.

Example
PDU: 
- `069146120621012404b6648900085221224185502524200c4f6076840020005800209a8c8bc17801662f00200034003000330033003000383002`
- Sender TON = 3 (network specific number)
- Expected output: `你的 X 验证码是 403308。`
- Actual output before fix: `┤‌你的 X 验证码是 403308。奙 뉞饙컿ﮨﺿ棵ꦻ꛼쨎ꢅ믮㞨れ ﺍ襙` (garbled)

Fix
In `decodeAddress`, when encountering an unsupported TON type or unknown EXT format, preserve the correct `addressLength` value (with odd-length adjustment) instead of setting it to 0. This ensures the caller can correctly skip over the address data even if we cannot decode it.